### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm i @windingtree/org.id
 // ABI
 const { OrgIdContract, OrgIdInterfaceContract, addresses } = require('@windingtree/org.id');
 // Contract addresses
-const { mainnet, ropsten } = addresses;
+const { main, ropsten } = addresses;
 ```
 
 ## Concept


### PR DESCRIPTION
Actual property name to get `mainnet` address is `main`. So the following code:

```
// ABI
const { OrgIdContract, OrgIdInterfaceContract, addresses } = require('@windingtree/org.id');

console.log(JSON.stringify(addresses))
```

Produces the following output:

```
{"main":"0x6434DEC2f4548C2aA9D88E8Ff821f387be3D7F0D","ropsten":"0x2cb8dCf26830B969555E04C2EDe3fc1D1BaD504E"}
```